### PR TITLE
Fix byte compile warnings

### DIFF
--- a/hlsl-mode.el
+++ b/hlsl-mode.el
@@ -44,10 +44,10 @@
 ;;; Code:
 
 (eval-when-compile                   ; required and optional libraries
-  (require 'cc-mode)
   (require 'find-file)
   (require 'subr-x))
 
+(require 'cc-mode)
 (require 'align)
 
 (defgroup hlsl nil


### PR DESCRIPTION
This package uses `cc-mode` functions, so `cc-mode` should not be loaded only compile time.

```
hlsl-mode.el:571:23: Warning: the function ‘c-update-modeline’ might not be
    defined at runtime.
hlsl-mode.el:570:23: Warning: the function ‘c-make-macro-with-semi-re’ might
    not be defined at runtime.
hlsl-mode.el:550:4: Warning: the function ‘cc-imenu-init’ might not be defined
    at runtime.
hlsl-mode.el:549:4: Warning: the function ‘c-common-init’ might not be defined
    at runtime.
hlsl-mode.el:548:4: Warning: the function ‘c-init-language-vars-for’ might not
    be defined at runtime.
```